### PR TITLE
Switch to providing extra context instead of overloading the whole view.

### DIFF
--- a/nautobot_plugin_wires/views.py
+++ b/nautobot_plugin_wires/views.py
@@ -19,25 +19,14 @@ class DeviceDetailWiresTab(generic.ObjectView):
     queryset = Device.objects.all()
     template_name = "nautobot_plugin_wires/tab_device_detail_wires.html"
 
-    def get(self, request, pk):
-        """
-        This method is called when a GET request is made to the view.
-
-        The request and pk are passed to the view from the URL definition.
-        """
-        device = Device.objects.get(id=pk)
+    def get_extra_context(self, request, device):
         report = CalculateWiresReportData(device)
         wired_ports = report.wired_ports
         header = report.header_fields
         report_data = report.report_data
 
-        return render(
-            request=self.request,
-            template_name=self.template_name,
-            context={
-                "object": device,
-                "wired_ports": wired_ports,
-                "header": header,
-                "report_data": report_data,
-            },
-        )
+        return {
+            "wired_ports": wired_ports,
+            "header": header,
+            "report_data": report_data,
+        }


### PR DESCRIPTION
Closes https://github.com/nautobot/nautobot/issues/2649.

The base template uses `verbose_name` [context parameter](https://github.com/nautobot/nautobot/blob/ltm/1.6/nautobot/core/templates/generic/object_retrieve.html#L74) which you aren't passing in your overloaded view. Instead of passing in all of the base context into your render function, `get_extra_context` exists to provide additional details and keeping the base rendering as expected (see how the other tab views are built: https://github.com/nautobot/nautobot/blob/f8beff126fe19622e3f8d356efc86479c209abe3/nautobot/dcim/views.py#L1565-L1580)

<img width="1473" alt="image" src="https://github.com/jifox/nautobot-plugin-wires/assets/31187/65734466-4aa0-4da2-b201-7fc22752fdbd">
